### PR TITLE
Use PUPPET_GEM_VERSION as environment variable

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -51,7 +51,7 @@ jobs:
         include: ${{fromJson(needs.setup_matrix.outputs.puppet_unit_test_matrix)}}
     env:
       BUNDLE_WITHOUT: development:system_tests:release
-      PUPPET_VERSION: "~> ${{ matrix.puppet }}.0"
+      PUPPET_GEM_VERSION: "~> ${{ matrix.puppet }}.0"
     name: ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -56,7 +56,7 @@ jobs:
         include: ${{fromJson(needs.setup_matrix.outputs.puppet_unit_test_matrix)}}
     env:
       BUNDLE_WITHOUT: development:system_tests:release
-      PUPPET_VERSION: "~> ${{ matrix.puppet }}.0"
+      PUPPET_GEM_VERSION: "~> ${{ matrix.puppet }}.0"
     name: ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -12,6 +12,71 @@ They are heavily focused on the workflow that Vox Pupuli uses, which rely on rak
 
 For more information, see [GitHub's workflow reuse documentation](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows).
 
+## Gemfile integration example
+
+Below is an annotated example Gemfile which should provide a working environment. It's the minimum needed.
+
+```ruby
+# The development group is intended for developer tooling. CI will never install this.
+group :development do
+end
+
+# The test group is used for static validations and unit tests in gha-puppet's
+# basic and beaker gha-puppet workflows.
+# Consider using https://github.com/voxpupuli/voxpupuli-test
+group :test do
+  # Require the latest Puppet by default unless a specific version was requested
+  # CI will typically set it to '~> 7.0' to get 7.x
+  gem 'puppet', ENV['PUPPET_GEM_VERSION'] || '>= 0', require: false
+  # Needed to build the test matrix based on metadata
+  gem 'puppet_metadata', '~> 1.0',  require: false
+  # Needed for the rake tasks
+  gem 'puppetlabs_spec_helper', '>= 2.16.0', '< 5', require: false
+  # Rubocop versions are also specific so it's recommended
+  # to be precise. Can be turned off via a parameter
+  gem 'rubocop', require: false
+end
+
+# The system_tests group is used in gha-puppet's beaker workflow.
+# Consider using https://github.com/voxpupuli/voxpupuli-acceptance
+group :system_tests do
+  gem 'beaker', require: false
+  gem 'beaker-docker', require: false
+  gem 'beaker-rspec', require: false
+end
+
+# The release group is used in gha-puppet's release workflow
+# Consider using https://github.com/voxpupuli/voxpupuli-release
+group :release do
+  gem 'puppet-blacksmith', '~> 6.0', require: false
+end
+```
+
+## Rakefile integration example
+
+This is the most minimal Rakefile you can have and still use all the shared
+actions.
+
+```ruby
+begin
+  require 'puppetlabs_spec_helper/rake_tasks'
+rescue LoadError
+  # Allowed to fail, only needed in test
+end
+
+begin
+  require 'beaker-rspec/rake_task'
+rescue LoadError
+  # Allowed to fail, only needed in acceptance
+end
+
+begin
+  require 'puppet_blacksmith/rake_tasks'
+rescue LoadError
+  # Allowed to fail, only needed in release
+end
+```
+
 ## Calling test workflows
 
 It is recommended to create a single workflow for all Puppet tests and name it `.github/workflows/puppet.yml`.


### PR DESCRIPTION
This copies what Puppet's PDK templates have used. While Vox Pupuli has historically used PUPPET_VERSION, this aligns the ecosystem. Foreman has also used PUPPET_VERSION, but as a plain version (forcing ~> in it) rather than the full specifier.

Before merging this I'd like to also add a solution to #5 and modify the modulesync PR.

Fixes #3