### PR TITLE
Adds basic workflow for pdk based modules

### DIFF
--- a/.github/workflows/pdk-basic.yml
+++ b/.github/workflows/pdk-basic.yml
@@ -12,25 +12,30 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        puppet-version: [7]
     container: ${{ inputs.container_image }}
-
+    outputs:
+        puppet_unit_test_matrix: ${{ steps.get-outputs.outputs.puppet_unit_test_matrix }}
+        github_action_test_matrix: ${{ steps.get-outputs.outputs.github_action_test_matrix }}
     steps:
       - uses: actions/checkout@v2
-      - name: action-pdk-validate-puppet-${{ matrix.puppet-version }}
-        run: pdk validate --puppet-version=${{ matrix.puppet-version }}
+      - name: action-pdk-validate-puppet-7
+        run: pdk validate --puppet-version=7
+      - run: gem install puppet_metadata --no-document 
+      - name: Setup Test Matrix
+        id: get-outputs
+        run: metadata2gha --use-fqdn
+  
 
   unit-puppet:
+    needs: 
+      - validate
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        puppet-version: [5, 6, 7]
+        include: ${{fromJson(needs.validate.outputs.puppet_unit_test_matrix)}}
     container: ${{ inputs.container_image }}
-    needs: validate
     steps:
       - uses: actions/checkout@v2
-
-      - name: action-pdk-test-unit-puppet-${{ matrix.puppet-version }}
-        run: pdk test unit --puppet-version=${{ matrix.puppet-version }}
+      - name: action-pdk-test-unit-puppet-${{ matrix.puppet }}
+        run: pdk test unit --puppet-version=${{ matrix.puppet }}

--- a/.github/workflows/pdk-basic.yml
+++ b/.github/workflows/pdk-basic.yml
@@ -1,0 +1,36 @@
+name: PDK basic
+
+on:
+  workflow_call:
+    inputs:
+      container_image:
+        description: Image to use when running tests
+        default: 'puppet/puppet-dev-tools:2022-04-21-e44b72b'
+        required: false
+        type: string
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        puppet-version: [7]
+    container: ${{ inputs.container_image }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: action-pdk-validate-puppet-${{ matrix.puppet-version }}
+        run: pdk validate --puppet-version=${{ matrix.puppet-version }}
+
+  unit-puppet:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        puppet-version: [5, 6, 7]
+    container: ${{ inputs.container_image }}
+    needs: validate
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: action-pdk-test-unit-puppet-${{ matrix.puppet-version }}
+        run: pdk test unit --puppet-version=${{ matrix.puppet-version }}

--- a/README.md
+++ b/README.md
@@ -214,3 +214,31 @@ jobs:
     uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v1
     working-directory: ./site/profiles
 ```
+
+## Cloning private repos
+If your CI pipline will clone private repos via the .fixtures.yml or Puppetfile
+you will need to supply a ssh private key for the runner to use during the job.
+
+That ssh private key can be a machine user's ssh key, or github deploy key.  As long 
+as the key has access to the repos it will need to clone.
+
+You will need to create a github secret for the private key named `PRIVATE_SSH_KEY`
+
+An example CI workflow is below for this kind of setup.
+
+For reference: https://stackoverflow.com/questions/57612428/cloning-private-github-repository-within-organisation-in-actions
+
+
+```yaml
+name: CI
+
+on: pull_request
+
+jobs:
+  puppet:
+    - name: Setup deploy key
+    run: eval `ssh-agent -s` && ssh-add - <<< '${{ secrets.PRIVATE_SSH_KEY }}'
+    - name: Puppet
+    uses: voxpupuli/gha-puppet/.github/workflows/pdk-basic.yml@master
+
+```


### PR DESCRIPTION
This provides a basic gha workflow for people using pdk.  I don't know if this is the correct spot for this workflow but thought I would add in case others want to reference or use.

I am a bit new to gha so this is missing a matrix and extra inputs for further configuration.  I don't know if configuration is necessary except for disabling jobs to save on resources.

The docker image `puppet/puppet-dev-tools:2022-03-28-92c7176` is the minimum required to make all this work and I don't suggest that the pdk image be used since it is not maintained. 

