### PR TITLE
Adds a puppetfile workflow that uses ra10ke

### DIFF
--- a/.github/workflows/puppetfile.yml
+++ b/.github/workflows/puppetfile.yml
@@ -1,0 +1,46 @@
+name: Puppetfile checks
+
+on:
+  workflow_call:
+    inputs:
+      container_image:
+        description: Image to use when running tests
+        default: 'puppet/puppet-dev-tools:2022-04-21-e44b72b'
+        required: false
+        type: string
+jobs:
+  r10k_validate:
+    runs-on: ubuntu-latest
+    container: ${{ inputs.container_image }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: validate Puppetfile
+        run: rake -f /Rakefile r10k:validate
+  r10k_check_dups:
+    runs-on: ubuntu-latest
+    container: ${{ inputs.container_image }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check for puppetfile duplicates
+        run: rake -f /Rakefile r10k:duplicates
+  r10k_syntax:
+    runs-on: ubuntu-latest
+    container: ${{ inputs.container_image }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check for puppetfile syntax correctness
+        run: rake -f /Rakefile r10k:syntax
+  r10k_deprecation:
+    runs-on: ubuntu-latest
+    container: ${{ inputs.container_image }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check for puppetfile module deprecations
+        run: rake -f /Rakefile r10k:deprecation          
+  r10k_find_outdated:
+    runs-on: ubuntu-latest
+    container: ${{ inputs.container_image }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check for outdated modules
+        run: rake -f /Rakefile r10k:dependencies    

--- a/README.md
+++ b/README.md
@@ -214,3 +214,26 @@ jobs:
     uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v1
     working-directory: ./site/profiles
 ```
+
+## Puppetfile checks
+You can use the puppetfile workflow to check various POI on your puppetfile.  To use this workflow do the following
+
+```yaml
+# This is a basic workflow to help you get started with Actions
+
+name: Puppetfile checks 
+
+# Controls when the workflow will run
+on:
+  push:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  puppetfile:
+    name: puppetfile 
+    uses:  voxpupuli/gha-puppet/.github/workflows//puppetfile.yml@master
+```


### PR DESCRIPTION
This is similar to #15 but checks the puppetfile.  This is geared towards the control repo.  The validate job is awesome but for private repos it won't work until authentication can be added.  So not sure how to handle that at the moment.  

Looking for feedback and any other jobs that should be added.

