### PR TITLE
beaker: pin to Ubuntu 20.04 images

### DIFF
--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -104,7 +104,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     needs: setup_matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       BUNDLE_WITHOUT: development:test:release
     strategy:


### PR DESCRIPTION
Ubuntu 22.04 don't work nicely with our CentOS 7 docker containers: https://github.com/voxpupuli/puppet-nginx/actions/runs/3649747029/jobs/6164834513

Related PR where I tested this:
* https://github.com/voxpupuli/puppet-nginx/pull/1524

Failing PR with ubuntu 22.04:
* https://github.com/voxpupuli/puppet-nginx/pull/1461