### PR TITLE
beaker: Set job-specific domain

### DIFF
--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -39,6 +39,11 @@ on:
         default: docker
         required: false
         type: string
+      domain:
+        description: The domain that will be used for the beaker instances
+        default: ${{ github.run_attempt }}-${{ github.run_id }}-${{ github.sha }}.example.com
+        required: false
+        type: string
 
 jobs:
   setup_matrix:
@@ -72,7 +77,7 @@ jobs:
         if: ${{ inputs.rubocop }}
       - name: Setup Test Matrix
         id: get-outputs
-        run: bundle exec metadata2gha --use-fqdn --pidfile-workaround ${{ inputs.pidfile_workaround }}
+        run: bundle exec metadata2gha --domain ${{ inputs.domain }} --pidfile-workaround ${{ inputs.pidfile_workaround }}
 
   unit:
     defaults:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ group :test do
   # CI will typically set it to '~> 7.0' to get 7.x
   gem 'puppet', ENV['PUPPET_GEM_VERSION'] || '>= 0', require: false
   # Needed to build the test matrix based on metadata
-  gem 'puppet_metadata', '~> 1.0',  require: false
+  gem 'puppet_metadata', '~> 1.10',  require: false
   # Needed for the rake tasks
   gem 'puppetlabs_spec_helper', '>= 2.16.0', '< 5', require: false
   # Rubocop versions are also specific so it's recommended


### PR DESCRIPTION
The used domain for beaker instances is now unique for each workflow run for each module we have.