### PR TITLE
Use a short domain

### DIFF
--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -41,7 +41,7 @@ on:
         type: string
       domain:
         description: The domain that will be used for the beaker instances
-        default: "n${{ github.run_attempt }}-${{ github.run_id }}-${{ github.sha }}.example.com"
+        default: "example.com"
         required: false
         type: string
 


### PR DESCRIPTION
This appears to pass (https://github.com/voxpupuli/puppet-yum/actions/runs/4143850584/jobs/7166195634) so it does appear to be related to the domain name.