### PR TITLE
CI: require Puppet 7.x in pipeline generation jobs

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -78,7 +78,7 @@ jobs:
         include: ${{fromJson(needs.setup_matrix.outputs.puppet_unit_test_matrix)}}
     env:
       BUNDLE_WITHOUT: development:system_tests:release
-      PUPPET_GEM_VERSION: "~> ${{ matrix.puppet }}.0"
+      PUPPET_GEM_VERSION: "~> ${{ matrix.puppet }}.24"
     name: ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -43,6 +43,7 @@ jobs:
       github_action_test_matrix: ${{ steps.get-outputs.outputs.github_action_test_matrix }}
     env:
       BUNDLE_WITHOUT: development:system_tests:release
+      PUPPET_GEM_VERSION: "~> 7.0"
     steps:
       - uses: actions/checkout@v3
       - name: install additional packages

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -93,7 +93,7 @@ jobs:
         include: ${{fromJson(needs.setup_matrix.outputs.puppet_unit_test_matrix)}}
     env:
       BUNDLE_WITHOUT: development:system_tests:release
-      PUPPET_GEM_VERSION: "~> ${{ matrix.puppet }}.0"
+      PUPPET_GEM_VERSION: "~> ${{ matrix.puppet }}.24"
     name: ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -58,6 +58,7 @@ jobs:
       github_action_test_matrix: ${{ steps.get-outputs.outputs.github_action_test_matrix }}
     env:
       BUNDLE_WITHOUT: development:system_tests:release
+      PUPPET_GEM_VERSION: "~> 7.0"
     steps:
       - uses: actions/checkout@v3
       - name: install additional packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,4 +48,5 @@ jobs:
           #  https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets
           BLACKSMITH_FORGE_USERNAME: '${{ secrets.username }}'
           BLACKSMITH_FORGE_API_KEY: '${{ secrets.api_key }}'
+          PUPPET_GEM_VERSION: "~> 7.0"
         run: bundle exec rake module:push


### PR DESCRIPTION
This is a bugfix because Puppet 8 was released without any prior announcement and broke everything and I just hate software and everything and don't want to fix a huge pile of broken PRs in the morning.