### PR TITLE
Revert "puppet: Require $major.24 or newer"

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -78,7 +78,7 @@ jobs:
         include: ${{fromJson(needs.setup_matrix.outputs.puppet_unit_test_matrix)}}
     env:
       BUNDLE_WITHOUT: development:system_tests:release
-      PUPPET_GEM_VERSION: "~> ${{ matrix.puppet }}.24"
+      PUPPET_GEM_VERSION: "~> ${{ matrix.puppet }}.0"
     name: ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -93,7 +93,7 @@ jobs:
         include: ${{fromJson(needs.setup_matrix.outputs.puppet_unit_test_matrix)}}
     env:
       BUNDLE_WITHOUT: development:system_tests:release
-      PUPPET_GEM_VERSION: "~> ${{ matrix.puppet }}.24"
+      PUPPET_GEM_VERSION: "~> ${{ matrix.puppet }}.0"
     name: ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This reverts commit 61fe7ccc296ae646433503165b2940a04bafea34.

Puppet 7.25 has removed the use of internal private classes form concurrent-ruby and removed the upper-bound on the dependency: https://github.com/puppetlabs/puppet/pull/9058

This upper-bound confused bundler which would install an old version of Puppet in order to use the latest version of concurrent-ruby, while we would prefer the latest version of Puppet with an older version of concurrent-ruby.

Now that the code has been fixed in Puppet, the hack is no longer necessary.


