### PR TITLE
Provide both a minimal example and a voxpupuli-* example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ modules (as documented in the next section). But they can also be configured to
 test modules that are vendored in a controlrepository or a monorepository. See
 [Working with a subdirectory](#Working-with-a-subdirectory) for details.
 
-## Gemfile integration example
+## Gemfile integration examples
 
 Below is an annotated example Gemfile which should provide a working environment. It's the minimum needed.
 
@@ -30,11 +30,47 @@ end
 
 # The test group is used for static validations and unit tests in gha-puppet's
 # basic and beaker gha-puppet workflows.
-# Consider using https://github.com/voxpupuli/voxpupuli-test
 group :test do
   # Require the latest Puppet by default unless a specific version was requested
   # CI will typically set it to '~> 7.0' to get 7.x
-  gem 'puppet', ENV['PUPPET_GEM_VERSION'] || '>= 0', require: false
+  gem 'puppet', ENV.fetch('PUPPET_GEM_VERSION', '>= 0'), require: false
+  # Needed to build the test matrix based on metadata
+  gem 'puppet_metadata', '>= 1.10', '< 4', require: false
+  # Needed for the rake tasks
+  gem 'puppetlabs_spec_helper', '>= 2.16.0', '< 7', require: false
+  # Rubocop versions are also specific so it's recommended
+  # to be precise. Can be turned off via a parameter
+  gem 'rubocop', require: false
+end
+
+# The system_tests group is used in gha-puppet's beaker workflow.
+group :system_tests do
+  gem 'beaker', require: false
+  gem 'beaker-docker', require: false
+  gem 'beaker-rspec', require: false
+end
+
+# The release group is used in gha-puppet's release workflow
+group :release do
+  gem 'puppet-blacksmith', '>= 6', '< 8', require: false
+end
+```
+
+It is recommended to use [voxpupuli-test](https://github.com/voxpupuli/voxpupuli-test), [voxpupuli-acceptance](https://github.com/voxpupuli/voxpupuli-acceptance), and [voxpupuli-release](https://github.com/voxpupuli/voxpupuli-release) to manage the dependencies.
+
+```ruby
+source 'https://rubygems.org'
+
+# The development group is intended for developer tooling. CI will never install this.
+group :development do
+end
+
+# The test group is used for static validations and unit tests in gha-puppet's
+# basic and beaker gha-puppet workflows.
+group :test do
+  # Require the latest Puppet by default unless a specific version was requested
+  # CI will typically set it to '~> 7.0' to get 7.x
+  gem 'puppet', ENV.fetch('PUPPET_GEM_VERSION', '>= 0'), require: false
   # Needed to build the test matrix based on metadata
   gem 'puppet_metadata', '~> 3.2',  require: false
   # metagem that pulls in all further requirements
@@ -42,13 +78,11 @@ group :test do
 end
 
 # The system_tests group is used in gha-puppet's beaker workflow.
-# Consider using https://github.com/voxpupuli/voxpupuli-acceptance
 group :system_tests do
   gem 'voxpupuli-acceptance', '~> 2.1', require: false
 end
 
 # The release group is used in gha-puppet's release workflow
-# Consider using https://github.com/voxpupuli/voxpupuli-release
 group :release do
   gem 'voxpupuli-release', '~> 3.0', '>= 3.0.1'
 end


### PR DESCRIPTION
In 2e4b26c393871ef5625d9aa3f34a9ac339ec2d10 the minimal example was rewritten to a voxpupuli-* example, but this goes against a core design principle that the action should be usable without those gems.

This commit brings back that minimal example, while also adding a full example with voxpupuli-* gems. The hints to the reader about those are removed from the minimal example.