### PR TITLE
Rely on puppet_metadata for the beaker name

### DIFF
--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -133,7 +133,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.setup_matrix.outputs.github_action_test_matrix)}}
         # TODO: beaker_fact_matrix input
-    name: "${{ matrix.puppet.value }} - ${{ matrix.setfile.name }}"
+    name: "${{ matrix.name }}"
     steps:
       - uses: actions/checkout@v4
       - name: install additional packages

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ group :test do
   # CI will typically set it to '~> 7.0' to get 7.x
   gem 'puppet', ENV.fetch('PUPPET_GEM_VERSION', '>= 0'), require: false
   # Needed to build the test matrix based on metadata
-  gem 'puppet_metadata', '>= 1.10', '< 4', require: false
+  gem 'puppet_metadata', '~> 3.3', require: false
   # Needed for the rake tasks
   gem 'puppetlabs_spec_helper', '>= 2.16.0', '< 7', require: false
   # Rubocop versions are also specific so it's recommended


### PR DESCRIPTION
puppet_metadata 3.3 started to provide the name of the matrix, which prepares for more complex setups where beaker provided facts are also reflected in the name.

I'd like to test this, so currently still a draft.