### PR TITLE
Remove --use-fqdn from basic.yml

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -68,7 +68,7 @@ jobs:
         if: ${{ inputs.rubocop }}
       - name: Setup Test Matrix
         id: get-outputs
-        run: bundle exec metadata2gha --use-fqdn
+        run: bundle exec metadata2gha
 
   unit:
     defaults:


### PR DESCRIPTION
This option only affects Beaker, and basic.yaml doesn't run beaker. It's also deprecated and will be dropped in the next version.