### PR TITLE
Create a GitHub release from each version tag

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,20 @@
+---
+name: GitHub Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release:
+    name: 'GitHub Release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2


### PR DESCRIPTION
This will add a GitHub release for any version tag pushed to the repo. This was requested by @bastelfreak at https://puppetcommunity.slack.com/archives/C0W1Y5VL0/p1715636371866939

The [gh-release action](https://github.com/marketplace/actions/gh-release) used here is both
  * the most popular action that implements the release functionality
  * the one I've had the most positive experiences with personally

Obviously this is a basic demonstration which could be further tuned to improve the release description, as per https://github.com/marketplace/actions/gh-release#-customizing