### PR TITLE
Switch runners to Ubuntu 24.04, use vagrant from hashicorp

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -31,7 +31,7 @@ on:
         type: string
       unit_runs_on:
         description: the runner group used for unit jobs run on
-        default: ubuntu-latest
+        default: ubuntu-24.04
         required: false
         type: string
 
@@ -41,7 +41,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     name: Static validations
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: ${{ inputs.timeout_minutes }}
     outputs:
       puppet_unit_test_matrix: ${{ steps.get-outputs.outputs.puppet_unit_test_matrix }}
@@ -102,7 +102,7 @@ jobs:
 
   tests:
     needs: unit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Test suite
     steps:
       - run: echo Test suite completed

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -56,7 +56,7 @@ on:
         type: string
       unit_runs_on:
         description: the runner group used for unit jobs run on
-        default: ubuntu-latest
+        default: ubuntu-24.04
         required: false
         type: string
       acceptance_runs_on:
@@ -78,7 +78,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     name: Static validations
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: ${{ inputs.timeout_minutes }}
     outputs:
       puppet_unit_test_matrix: ${{ steps.get-outputs.outputs.puppet_unit_test_matrix }}
@@ -183,7 +183,7 @@ jobs:
     needs:
       - unit
       - acceptance
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Test suite
     steps:
       - run: echo Test suite completed

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -61,7 +61,7 @@ on:
         type: string
       acceptance_runs_on:
         description: the runner group used for acceptance jobs run on
-        default: ubuntu-20.04
+        default: ubuntu-24.04
         required: false
         type: string
     secrets:

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -166,7 +166,9 @@ jobs:
         if: ${{ inputs.beaker_hypervisor == 'vagrant_libvirt' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends vagrant vagrant-libvirt libvirt-clients libvirt-daemon-system libvirt-daemon qemu qemu-system-x86 qemu-utils
+          wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          sudo apt-get install -y --no-install-recommends vagrant vagrant-libvirt libvirt-clients libvirt-daemon-system libvirt-daemon qemu-system qemu-system-x86 qemu-utils
           sudo chmod 666 /var/run/libvirt/libvirt-sock
       - name: Setup ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -168,7 +168,7 @@ jobs:
           wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
           echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends vagrant libvirt-dev libvirt-clients libvirt-daemon-system libvirt-daemon qemu-system qemu-system-x86 qemu-utils
+          sudo apt-get install -y --no-install-recommends dnsmasq vagrant libvirt-dev libvirt-clients libvirt-daemon-system libvirt-daemon qemu-system qemu-system-x86 qemu-utils
           sudo chmod 666 /var/run/libvirt/libvirt-sock
       - name: Setup ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -168,8 +168,9 @@ jobs:
           wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
           echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends vagrant vagrant-libvirt libvirt-clients libvirt-daemon-system libvirt-daemon qemu-system qemu-system-x86 qemu-utils
+          sudo apt-get install -y --no-install-recommends vagrant libvirt-clients libvirt-daemon-system libvirt-daemon qemu-system qemu-system-x86 qemu-utils
           sudo chmod 666 /var/run/libvirt/libvirt-sock
+          sudo vagrant plugin install vagrant-libvirt
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -168,7 +168,7 @@ jobs:
           wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
           echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends vagrant libvirt-clients libvirt-daemon-system libvirt-daemon qemu-system qemu-system-x86 qemu-utils
+          sudo apt-get install -y --no-install-recommends vagrant libvirt-dev libvirt-clients libvirt-daemon-system libvirt-daemon qemu-system qemu-system-x86 qemu-utils
           sudo chmod 666 /var/run/libvirt/libvirt-sock
           sudo vagrant plugin install vagrant-libvirt
       - name: Setup ruby

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -165,9 +165,9 @@ jobs:
       - name: Setup libvirt for Vagrant
         if: ${{ inputs.beaker_hypervisor == 'vagrant_libvirt' }}
         run: |
-          sudo apt-get update
           wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
           echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          sudo apt-get update
           sudo apt-get install -y --no-install-recommends vagrant vagrant-libvirt libvirt-clients libvirt-daemon-system libvirt-daemon qemu-system qemu-system-x86 qemu-utils
           sudo chmod 666 /var/run/libvirt/libvirt-sock
       - name: Setup ruby

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -170,7 +170,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends vagrant libvirt-dev libvirt-clients libvirt-daemon-system libvirt-daemon qemu-system qemu-system-x86 qemu-utils
           sudo chmod 666 /var/run/libvirt/libvirt-sock
-          sudo vagrant plugin install vagrant-libvirt
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -178,6 +177,10 @@ jobs:
           bundler-cache: true
           cache-version: ${{ inputs.cache-version }}
           working-directory: ${{ inputs.working-directory }}
+      - name: Final vagrant setup
+        if: ${{ inputs.beaker_hypervisor == 'vagrant_libvirt' }}
+        run: |
+          vagrant plugin install vagrant-libvirt
       - name: Run tests
         run: bundle exec rake beaker
         env: ${{ matrix.env }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     name: 'Puppet Forge'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.repository_owner == inputs.allowed_owner
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This is to help get https://github.com/voxpupuli/puppet-selinux/pull/390 working. Selinux is low level enough we need vagrant with libvirt, but to test with AlmaLinux we need a newer version of Vagrant. AlmaLinux uses box v2 standard for vagrant thus requiring newer builds. We MAY be able to backport to 20.04 with some work if that is the preferred path. I also saw better perf, and less random build failures with 24.04 than I was on 20.04 vagrant.