### PR TITLE
CI: Use Ubuntu 22.04, not -latest

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -31,7 +31,7 @@ on:
         type: string
       unit_runs_on:
         description: the runner group used for unit jobs run on
-        default: ubuntu-latest
+        default: ubuntu-22.04
         required: false
         type: string
 
@@ -41,7 +41,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     name: Static validations
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: ${{ inputs.timeout_minutes }}
     outputs:
       puppet_unit_test_matrix: ${{ steps.get-outputs.outputs.puppet_unit_test_matrix }}
@@ -102,7 +102,7 @@ jobs:
 
   tests:
     needs: unit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Test suite
     steps:
       - run: echo Test suite completed

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -56,7 +56,7 @@ on:
         type: string
       unit_runs_on:
         description: the runner group used for unit jobs run on
-        default: ubuntu-latest
+        default: ubuntu-22.04
         required: false
         type: string
       acceptance_runs_on:
@@ -78,7 +78,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     name: Static validations
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: ${{ inputs.timeout_minutes }}
     outputs:
       puppet_unit_test_matrix: ${{ steps.get-outputs.outputs.puppet_unit_test_matrix }}
@@ -183,7 +183,7 @@ jobs:
     needs:
       - unit
       - acceptance
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Test suite
     steps:
       - run: echo Test suite completed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     name: 'Puppet Forge'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository_owner == inputs.allowed_owner
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The latest tag will be moved from Ubuntu 22.04 to 24.04 in the future. To prevent us from pulling in unexpected updates, we explicitly pinto 22.04. The V3 branch in gha-puppet will be pinned to 24.04.