### PR TITLE
v3: Run on Ubuntu 24.04

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -31,7 +31,7 @@ on:
         type: string
       unit_runs_on:
         description: the runner group used for unit jobs run on
-        default: ubuntu-latest
+        default: ubuntu-24.04
         required: false
         type: string
 
@@ -41,7 +41,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     name: Static validations
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: ${{ inputs.timeout_minutes }}
     outputs:
       puppet_unit_test_matrix: ${{ steps.get-outputs.outputs.puppet_unit_test_matrix }}
@@ -102,7 +102,7 @@ jobs:
 
   tests:
     needs: unit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Test suite
     steps:
       - run: echo Test suite completed

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -56,7 +56,7 @@ on:
         type: string
       unit_runs_on:
         description: the runner group used for unit jobs run on
-        default: ubuntu-latest
+        default: ubuntu-24.04
         required: false
         type: string
       acceptance_runs_on:
@@ -78,7 +78,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     name: Static validations
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: ${{ inputs.timeout_minutes }}
     outputs:
       puppet_unit_test_matrix: ${{ steps.get-outputs.outputs.puppet_unit_test_matrix }}
@@ -183,7 +183,7 @@ jobs:
     needs:
       - unit
       - acceptance
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Test suite
     steps:
       - run: echo Test suite completed

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -61,7 +61,7 @@ on:
         type: string
       acceptance_runs_on:
         description: the runner group used for acceptance jobs run on
-        default: ubuntu-20.04
+        default: ubuntu-24.04
         required: false
         type: string
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     name: 'Puppet Forge'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.repository_owner == inputs.allowed_owner
     steps:
       - name: Checkout repository


### PR DESCRIPTION
In reference to https://github.com/voxpupuli/gha-puppet/pull/57#issuecomment-2225591216, updating the images on v3 to Ubuntu 24.04