### PR TITLE
fix compat. with modulesync_config 9.2.0; rm PUPPET_GEM_VERSION

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,5 +48,4 @@ jobs:
           #  https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets
           BLACKSMITH_FORGE_USERNAME: '${{ secrets.username }}'
           BLACKSMITH_FORGE_API_KEY: '${{ secrets.api_key }}'
-          PUPPET_GEM_VERSION: "~> 7.0"
         run: bundle exec rake module:push


### PR DESCRIPTION
Resolves this error:

    /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/3.2.0/bundler/resolver.rb:304:in `raise_not_found!': Could not find gem 'puppet (~> 7.0)' in locally installed gems. (Bundler::GemNotFound)

This appears to have been caused by this change:

https://github.com/voxpupuli/modulesync_config/pull/925

Which allows the version of puppet installed in the bundle to be >= 8.