### PR TITLE
disable apparmor for beaker acceptance test

### DIFF
--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -162,6 +162,11 @@ jobs:
     name: "${{ matrix.name }}"
     steps:
       - uses: actions/checkout@v4
+      - name: disable apparmor
+        run: |
+          # https://bugs.launchpad.net/ubuntu/+source/apparmor/+bug/2093797
+          sudo aa-teardown || true
+          sudo systemctl disable --now apparmor.service
       - name: install additional packages
         if: ${{ inputs.additional_packages != '' }}
         run: |


### PR DESCRIPTION
apparmor on a Ubuntu 24.04 host breaks things, like `sudo` or `ssh` within a RHEL based container (and maybe others).

As there's [a bug](https://bugs.launchpad.net/ubuntu/+source/apparmor/+bug/2093797) in `aa-teardown`, it fails the action run. That's why I've added the `|| true` part, to avoid failing the run.