### PR TITLE
Make rspec-puppet rake task configureable

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -34,6 +34,11 @@ on:
         default: ubuntu-24.04
         required: false
         type: string
+      unit_tests_rake_task:
+        description: The rake task that will be executed to run run rspec-puppet
+        default: parallel_spec
+        required: false
+        type: string
 
 jobs:
   setup_matrix:
@@ -98,7 +103,7 @@ jobs:
           cache-version: ${{ inputs.cache-version }}
           working-directory: ${{ inputs.working-directory }}
       - name: Run tests
-        run: bundle exec rake parallel_spec
+        run: bundle exec rake ${{ inputs.unit_tests_rake_task }}
 
   tests:
     if: always()

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -69,6 +69,11 @@ on:
         default: ubuntu-24.04
         required: false
         type: string
+      unit_tests_rake_task:
+        description: The rake task that will be executed to run run rspec-puppet
+        default: parallel_spec
+        required: false
+        type: string
     secrets:
       beaker_hcloud_token:
         description: token to access the Hetzner Cloud API
@@ -144,7 +149,7 @@ jobs:
           cache-version: ${{ inputs.cache-version }}
           working-directory: ${{ inputs.working-directory }}
       - name: Run tests
-        run: bundle exec rake parallel_spec
+        run: bundle exec rake ${{ inputs.unit_tests_rake_task }}
 
   acceptance:
     defaults:


### PR DESCRIPTION
By default, we use the parallel_spec task. Some modules might have tests that call out to external APIs, where tests need to be run sequentially, not in parallel (e.g. puppet-vault_hiera).

Required for https://github.com/voxpupuli/puppet-hiera_vault/pull/100