### PR TITLE
Fix attaching modules from non-puppet namespace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,4 +60,4 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload ${{ github.ref_name }} pkg/puppet-*tar.gz
+        run: gh release upload ${{ github.ref_name }} pkg/*.tar.gz


### PR DESCRIPTION
VoxPupuli use the `puppet` namespace and its modules artifacts are named puppet-*.tar.gz, but other organization have a different namespace and using the task fail because the filename does not match the pattern.

The modulesync_config configuration ensure that the `pkg` directory is ignored, so we can consider it to not be part of the module repository, and at the time this command is run to only contain the latest build of the module that we want to attach.

This will fix failures such as:
https://github.com/opus-codium/puppet-taiga/actions/runs/14762072331/job/41444875812#step:6:9
