### PR TITLE
Output `bundle env` after installing gems

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -61,6 +61,8 @@ jobs:
           bundler-cache: true
           cache-version: ${{ inputs.cache-version }}
           working-directory: ${{ inputs.working-directory }}
+      - name: Display Ruby environment
+        run: bundle env
       - name: Run static validations
         run: bundle exec rake validate lint check
       - name: Run rake rubocop
@@ -97,6 +99,8 @@ jobs:
           bundler-cache: true
           cache-version: ${{ inputs.cache-version }}
           working-directory: ${{ inputs.working-directory }}
+      - name: Display Ruby environment
+        run: bundle env
       - name: Run tests
         run: bundle exec rake parallel_spec
 

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -105,6 +105,8 @@ jobs:
           bundler-cache: true
           cache-version: ${{ inputs.cache-version }}
           working-directory: ${{ inputs.working-directory }}
+      - name: Display Ruby environment
+        run: bundle env
       - name: Run static validations
         run: bundle exec rake validate lint check
       - name: Run rake rubocop
@@ -143,6 +145,8 @@ jobs:
           bundler-cache: true
           cache-version: ${{ inputs.cache-version }}
           working-directory: ${{ inputs.working-directory }}
+      - name: Display Ruby environment
+        run: bundle env
       - name: Run tests
         run: bundle exec rake parallel_spec
 
@@ -192,6 +196,8 @@ jobs:
           cache-version: ${{ inputs.cache-version }}
           working-directory: ${{ inputs.working-directory }}
           self-hosted: ${{ ! startsWith(inputs.acceptance_runs_on, 'ubuntu-') }}
+      - name: Display Ruby environment
+        run: bundle env
       - name: Run tests
         run: bundle exec rake beaker
         env: ${{ matrix.env }}

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -54,10 +54,8 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
           working-directory: ${{ inputs.working-directory }}
-      - name: bundle environment
-        run: |
-          bundle env
-          bundle list
+      - name: Display Ruby environment
+        run: bundle env
       - name: Update metadata.json to new version
         run: |
           if [[ -n BLACKSMITH_FULL_VERSION ]] ; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
           ruby-version: '3.2'
           bundler-cache: true
           working-directory: ${{ inputs.working-directory }}
+      - name: Display Ruby environment
+        run: bundle env
       - name: Build and Release
         env:
           # Configure secrets here:


### PR DESCRIPTION
Sometimes GitHub just restores a cache for the vendor dir. In that case we do not know which gems are actually installed.

tested in https://github.com/voxpupuli/puppet-example/pull/120