### PR TITLE
Always set PUPPET_GEM_VERSION & OPENVOX_GEM_VERSION environment variables

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -49,6 +49,7 @@ jobs:
     env:
       BUNDLE_WITHOUT: development:system_tests:release
       PUPPET_GEM_VERSION: ">= 7.0"
+      OPENVOX_GEM_VERSION: ">= 7.0"
     steps:
       - uses: actions/checkout@v4
       - name: install additional packages
@@ -86,6 +87,7 @@ jobs:
     env:
       BUNDLE_WITHOUT: development:system_tests:release
       PUPPET_GEM_VERSION: "~> ${{ matrix.puppet }}.0"
+      OPENVOX_GEM_VERSION: "~> ${{ matrix.puppet }}.0"
     name: ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -91,6 +91,7 @@ jobs:
     env:
       BUNDLE_WITHOUT: development:system_tests:release
       PUPPET_GEM_VERSION: ">= 7.0"
+      OPENVOX_GEM_VERSION: ">= 7.0"
     steps:
       - uses: actions/checkout@v4
       - name: install additional packages
@@ -130,6 +131,7 @@ jobs:
     env:
       BUNDLE_WITHOUT: development:system_tests:release
       PUPPET_GEM_VERSION: "~> ${{ matrix.puppet }}.0"
+      OPENVOX_GEM_VERSION: "~> ${{ matrix.puppet }}.0"
     name: ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
In the v4 version we can remove PUPPET_GEM_VERSION