### PR TITLE
Improve job names

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -1,5 +1,5 @@
 ---
-name: Puppet
+name: Unit
 
 on:
   workflow_call:
@@ -88,7 +88,7 @@ jobs:
       BUNDLE_WITHOUT: development:system_tests:release
       PUPPET_GEM_VERSION: "~> ${{ matrix.puppet }}.0"
       OPENVOX_GEM_VERSION: "~> ${{ matrix.puppet }}.0"
-    name: ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
+    name: OpenVox ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
     steps:
       - uses: actions/checkout@v4
       - name: install additional packages

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -1,5 +1,5 @@
 ---
-name: Puppet
+name: Acceptance
 
 on:
   workflow_call:


### PR DESCRIPTION
Both unit tests and acceptance tests are named "Puppet", given we test
against OpenVox this is a bit confusing as "CI / Puppet / 8 (Ruby 3.2)"
feels like tests are running against Puppet, and "CI / Puppet / OpenVox
8 - Debian 12" is not clear about what is being tested.

Update the workflow names to distinguish unit tests from acceptance
tests in a tooling agnostic way, and update the unit test job name to
reflect the fact that tests are run against OpenVox.
