### PR TITLE
beaker: Set default hypervisor to container_podman & Remove pidfile workaround option

### DIFF
--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -36,7 +36,7 @@ on:
         type: string
       beaker_hypervisor:
         description: The hypervisor beaker will use to start containers/VMs
-        default: docker
+        default: container_podman
         required: false
         type: string
       install_vagrant_dependencies:

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -4,11 +4,6 @@ name: Puppet
 on:
   workflow_call:
     inputs:
-      pidfile_workaround:
-        description: How to apply the systemd PIDFile workaround for acceptance tests, if at all
-        default: 'false'
-        required: false
-        type: string
       rubocop:
         description: Whether to run Rubocop
         default: true
@@ -115,7 +110,7 @@ jobs:
         if: ${{ inputs.rubocop }}
       - name: Setup Test Matrix
         id: get-outputs
-        run: bundle exec metadata2gha --domain ${{ inputs.domain }} --pidfile-workaround ${{ inputs.pidfile_workaround }} --beaker-facter "${{ inputs.beaker_facter }}" --beaker-hosts "${{ inputs.beaker_hosts }}"
+        run: bundle exec metadata2gha --domain ${{ inputs.domain }} --beaker-facter "${{ inputs.beaker_facter }}" --beaker-hosts "${{ inputs.beaker_hosts }}"
 
   unit:
     defaults:


### PR DESCRIPTION
note: this goes into the new v4 branch, we are currently using v4.