### PR TITLE
Support rootful podman beaker tests

### DIFF
--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -189,6 +189,7 @@ jobs:
           sudo chmod 0777 /run/podman
           sudo chmod 0666 /run/podman/podman.sock
           echo "DOCKER_HOST=unix:///run/podman/podman.sock" >> "$GITHUB_ENV"
+          echo "CONTAINER_HOST=unix:///run/podman/podman.sock" >> "$GITHUB_ENV"
       - name: Setup libvirt for Vagrant
         if: ${{ inputs.beaker_hypervisor == 'vagrant_libvirt' && inputs.install_vagrant_dependencies == true }}
         run: |

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -204,6 +204,11 @@ jobs:
           cache-version: ${{ inputs.cache-version }}
           working-directory: ${{ inputs.working-directory }}
           self-hosted: ${{ ! startsWith(inputs.acceptance_runs_on, 'ubuntu-') }}
+      - name: Debug with tmate (pre-hang)
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+        timeout-minutes: 1200 
       - name: Display Ruby environment
         run: bundle env
       - name: Run tests

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -205,11 +205,6 @@ jobs:
           cache-version: ${{ inputs.cache-version }}
           working-directory: ${{ inputs.working-directory }}
           self-hosted: ${{ ! startsWith(inputs.acceptance_runs_on, 'ubuntu-') }}
-      - name: Debug with tmate (pre-hang)
-        uses: mxschmitt/action-tmate@v3
-        with:
-          limit-access-to-actor: true
-        timeout-minutes: 1200 
       - name: Display Ruby environment
         run: bundle env
       - name: Run tests

--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -34,6 +34,11 @@ on:
         default: container_podman
         required: false
         type: string
+      podman_rootful:
+        description: If true use the rootful podman socket.
+        default: false
+        required: false
+        type: boolean
       install_vagrant_dependencies:
         description: When true and beaker_hypervisor==vagrant_libvirt, we will install vagrant + libvirt
         default: true
@@ -178,6 +183,12 @@ jobs:
         run: |
           systemctl start --user podman.socket
           echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+      - if: ${{ inputs.podman_rootful }}
+        run: |
+          sudo systemctl start podman.socket
+          sudo chmod 0777 /run/podman
+          sudo chmod 0666 /run/podman/podman.sock
+          echo "DOCKER_HOST=unix:///run/podman/podman.sock" >> "$GITHUB_ENV"
       - name: Setup libvirt for Vagrant
         if: ${{ inputs.beaker_hypervisor == 'vagrant_libvirt' && inputs.install_vagrant_dependencies == true }}
         run: |


### PR DESCRIPTION
Even a `--privileged` rootless podman container is unable to do some operations.

If `podman_rootful` is set `true` (default false) then `/run/podman/podman.socket`

What cannot be done in a privileged rootless container ? Obvious one is interact with kernel modules for instance.

The vast majority of modules will be fine with rootless containers and its much closer to what folk typically run on the their laptops so the current behaviour makes a sensible default.