### PR TITLE
Create the GitHub release with files in one step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,4 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create ${{ github.ref_name }} --generate-notes
-      - name: Attach puppet module to GitHub Release
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release upload ${{ github.ref_name }} pkg/*.tar.gz
+        run: gh release create ${{ github.ref_name }} pkg/*.tar.gz --generate-notes


### PR DESCRIPTION
Create and attach the files for the GitHub release in one step in the release workflow, so it should work with immutable releases.

Fixes https://github.com/voxpupuli/gha-puppet/issues/87
