### PR TITLE
Implement support for installing staging packages

### DIFF
--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -49,6 +49,28 @@ on:
         default: 'false'
         required: false
         type: string
+      beaker_staging_url:
+        description: |-
+          URL to a staging Server to test unreleased packages.
+          We will append the version to the Server and assume all packages are in the same directory.
+          Only supported for AIO packages.
+        default: 'https://artifacts.voxpupuli.org/openvox-agent'
+        required: false
+        type: string
+      beaker_collection:
+        description: |-
+          When set to staging, we will download the packages from staging_url.
+          Otherwise we will use the official repos. Supported values: puppet7, puppet8, openvox7, openvox8, staging.
+          When unset, we will generate a list of supported collections based on metadata.json.
+        required: false
+        type: string
+      beaker_staging_version:
+        description: |-
+          The package version we want to test.
+          Only used for beaker_collection = staging
+        required: false
+        type: string
+
       domain:
         description: The domain that will be used for the beaker instances
         default: "example.com"
@@ -87,6 +109,7 @@ jobs:
       BUNDLE_WITHOUT: development:system_tests:release
       PUPPET_GEM_VERSION: ">= 7.0"
       OPENVOX_GEM_VERSION: ">= 7.0"
+      BEAKER_STAGING_VERSION: ${{ inputs.beaker_staging_version }}
     steps:
       - uses: actions/checkout@v6
       - name: install additional packages
@@ -110,7 +133,7 @@ jobs:
         if: ${{ inputs.rubocop }}
       - name: Setup Test Matrix
         id: get-outputs
-        run: bundle exec metadata2gha --domain ${{ inputs.domain }} --beaker-facter "${{ inputs.beaker_facter }}" --beaker-hosts "${{ inputs.beaker_hosts }}"
+        run: bundle exec metadata2gha --domain ${{ inputs.domain }} --beaker-facter "${{ inputs.beaker_facter }}" --beaker-hosts "${{ inputs.beaker_hosts }}" --collection "${{ inputs.beaker_collection }}"
 
   unit:
     defaults:
@@ -156,6 +179,7 @@ jobs:
     env:
       BUNDLE_WITHOUT: development:test:release
       BEAKER_HCLOUD_TOKEN: '${{ secrets.beaker_hcloud_token }}'
+      BEAKER_STAGING_VERSION: ${{ inputs.beaker_staging_version }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
relates to:
* https://github.com/voxpupuli/voxpupuli-acceptance/pull/132
* https://github.com/voxpupuli/beaker_puppet_helpers/pull/102
* https://github.com/voxpupuli/puppet-example/pull/147
* https://github.com/voxpupuli/puppet_metadata/pull/220
* https://github.com/voxpupuli/modulesync_config/pull/1028

This enhances our GitHub workflows. Puppet modules with acceptance tests will now have a trigger to manually run them. And users can configure a specific collection that shall be tested, e.g. openvox7, openvox8 or staging. For staging, you can provide a build version. This will be fetched from https://artifacts.voxpupuli.org/openvox-agent/.

---

The workflow can be triggered via API. This allows us to test new openvox-agent builds on 125 modules \o/ :tada: 