### PR TITLE
Only pass --collection to metadata2gha if set

### DIFF
--- a/.github/workflows/beaker.yml
+++ b/.github/workflows/beaker.yml
@@ -133,7 +133,9 @@ jobs:
         if: ${{ inputs.rubocop }}
       - name: Setup Test Matrix
         id: get-outputs
-        run: bundle exec metadata2gha --domain ${{ inputs.domain }} --beaker-facter "${{ inputs.beaker_facter }}" --beaker-hosts "${{ inputs.beaker_hosts }}" --collection "${{ inputs.beaker_collection }}"
+        run: bundle exec metadata2gha --domain ${{ inputs.domain }} --beaker-facter "${{ inputs.beaker_facter }}" --beaker-hosts "${{ inputs.beaker_hosts }}" ${COLLECTION:+--collection "${COLLECTION}"}
+        env:
+          COLLECTION: ${{ inputs.beaker_collection }}
 
   unit:
     defaults:


### PR DESCRIPTION
This brings back compatibility with older metadata2gha that doesn't support --collection.

Tested in https://github.com/theforeman/puppet-pulpcore/pull/401.

Fixes: fd171ad3be28029f16e54a8aaf039f906c0aaa04 ("Implement support for installing staging packages")